### PR TITLE
Export PlayFab from PlayFabClientApi

### DIFF
--- a/PlayFabSdk/src/PlayFab/PlayFabClientApi.js
+++ b/PlayFabSdk/src/PlayFab/PlayFabClientApi.js
@@ -1384,3 +1384,4 @@ PlayFab.RegisterWithPhaser = function() {
 };
 PlayFab.RegisterWithPhaser();
 
+export default PlayFab


### PR DESCRIPTION
In order to use PlayFabClientApi with module bundlers, it should be exported.